### PR TITLE
Fix NOCONTENT + PAYLOAD in search

### DIFF
--- a/redisearch/client.py
+++ b/redisearch/client.py
@@ -25,7 +25,7 @@ class Field(object):
     def __init__(self, name, *args):
         self.name = name
         self.args = args
-    
+
     def redis_args(self):
         return [self.name] + list(self.args)
 
@@ -80,7 +80,7 @@ class GeoField(Field):
 
 class TagField(Field):
     """
-    TagField is a tag-indexing field with simpler compression and tokenization. 
+    TagField is a tag-indexing field with simpler compression and tokenization.
     See http://redisearch.io/Tags/
     """
     def __init__(self, name, separator = ',', no_index=False):
@@ -91,12 +91,12 @@ class TagField(Field):
 
         if no_index:
             self.args.append(Field.NOINDEX)
-    
+
 
 class Client(object):
     """
-    A client for the RediSearch module. 
-    It abstracts the API of the module and lets you just use the engine 
+    A client for the RediSearch module.
+    It abstracts the API of the module and lets you just use the engine
     """
 
     NUMERIC = 'NUMERIC'
@@ -117,8 +117,8 @@ class Client(object):
 
     class BatchIndexer(object):
         """
-        A batch indexer allows you to automatically batch 
-        document indexeing in pipelines, flushing it every N documents. 
+        A batch indexer allows you to automatically batch
+        document indexeing in pipelines, flushing it every N documents.
         """
 
         def __init__(self, client, chunk_size=1000):
@@ -193,7 +193,7 @@ class Client(object):
             args += [self.STOPWORDS, len(stopwords)]
             if len(stopwords) > 0:
                 args += list(stopwords)
-    
+
         args.append('SCHEMA')
 
         args += list(itertools.chain(*(f.redis_args() for f in fields)))
@@ -205,11 +205,11 @@ class Client(object):
         Drop the index if it exists
         """
         return self.redis.execute_command(self.DROP_CMD, self.index_name)
-        
+
     def _add_document(self, doc_id, conn=None, nosave=False, score=1.0, payload=None,
                       replace=False, partial=False, language=None, **fields):
-        """ 
-        Internal add_document used for both batch and single doc indexing 
+        """
+        Internal add_document used for both batch and single doc indexing
         """
         if conn is None:
             conn = self.redis
@@ -242,17 +242,17 @@ class Client(object):
 
         - **doc_id**: the id of the saved document.
         - **nosave**: if set to true, we just index the document, and don't save a copy of it. This means that searches will just return ids.
-        - **score**: the document ranking, between 0.0 and 1.0 
+        - **score**: the document ranking, between 0.0 and 1.0
         - **payload**: optional inner-index payload we can save for fast access in scoring functions
         - **replace**: if True, and the document already is in the index, we perform an update and reindex the document
         - **partial**: if True, the fields specified will be added to the existing document.
                        This has the added benefit that any fields specified with `no_index`
                        will not be reindexed again. Implies `replace`
         - **language**: Specify the language used for document tokenization.
-        - **fields** kwargs dictionary of the document fields to be saved and/or indexed. 
+        - **fields** kwargs dictionary of the document fields to be saved and/or indexed.
                      NOTE: Geo points shoule be encoded as strings of "lon,lat"
         """
-        return self._add_document(doc_id, conn=None, nosave=nosave, score=score, 
+        return self._add_document(doc_id, conn=None, nosave=nosave, score=score,
                                   payload=payload, replace=replace,
                                   partial=partial, language=language, **fields)
 

--- a/redisearch/result.py
+++ b/redisearch/result.py
@@ -18,23 +18,28 @@ class Result(object):
         self.docs = []
 
         step = 1
-        if hascontent:
-            step = 3 if has_payload else 2
-        else:
-            # we can't have nocontent and payloads in the same response
-            has_payload = False
+        fields_offset = 0
+        if hascontent and has_payload:
+            step = 3
+            fields_offset = 2
+        elif hascontent and not has_payload:
+            step = 2
+            fields_offset = 1
+        elif not hascontent and has_payload:
+            step = 2
+            fields_offset = 0
 
         for i in xrange(1, len(res), step):
             id = to_string(res[i])
             payload = to_string(res[i+1]) if has_payload else None
-            fields_offset = 2 if has_payload else 1
 
-            fields = {} 
-            if hascontent:
+            fields = {}
+            if fields_offset > 0:
                 fields = dict(
                     dict(izip(map(to_string, res[i + fields_offset][::2]),
                               map(to_string, res[i + fields_offset][1::2])))
-                ) if hascontent else {}
+                )
+
             try:
                 del fields['id']
             except KeyError:


### PR DESCRIPTION
Hi! Thanks for redisearch!

I'm trying to use PAYLOAD with NOCONTENT. `redisearch-py` returns incorrect ids and payloads in current implementation. So this test will fail:
```python
    def testPayloadsWithNoContent(self):
        conn = self.redis()

        with conn as r:
            # Creating a client with a given index name
            client = Client('idx', port=conn.port)
            client.redis.flushdb()
            client.create_index((TextField('txt'),))

            client.add_document('doc1', payload = 'foo baz', txt = 'foo bar')
            client.add_document('doc2', payload = 'foo baz2', txt = 'foo bar')

            q = Query("foo bar").with_payloads().no_content()
            res = client.search(q)

            self.assertEqual(2, len(res.docs))
```

```
======================================================================
FAIL: testPayloadsWithNoContent (__main__.RedisSearchTestCase)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "test/test.py", line 214, in testPayloadsWithNoContent
    self.assertEqual(2, len(res.docs[0].id))
AssertionError: 2 != 4
```

But I'm not sure it is correct to use PAYLOAD and NOCONTENT together or no because i've found this comment in source code: `# we can't have nocontent and payloads in the same response`.