### PR TITLE
 split install requirement packages  to install and test.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,8 @@ setup(
     description='RedisSearch Python Client',
     url='http://github.com/RedisLabs/redisearch-py',
     packages=find_packages(),
-    install_requires=['redis', 'hiredis', 'rmtest'],
+    install_requires=['redis', 'hiredis'],
+    test_require=['rmtest'],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Intended Audience :: Developers',


### PR DESCRIPTION
I just tried to generate a rpm package from this repo by **fpm** . It shows that there are some conflicts between rmtest and redisearch-py.

```
rpm -qlp python-redisearch-0.7.1-1.noarch.rpm
/usr/lib/python2.7/site-packages/redisearch-0.7.1-py2.7.egg-info/PKG-INFO
/usr/lib/python2.7/site-packages/redisearch-0.7.1-py2.7.egg-info/SOURCES.txt
/usr/lib/python2.7/site-packages/redisearch-0.7.1-py2.7.egg-info/dependency_links.txt
/usr/lib/python2.7/site-packages/redisearch-0.7.1-py2.7.egg-info/requires.txt
/usr/lib/python2.7/site-packages/redisearch-0.7.1-py2.7.egg-info/top_level.txt
/usr/lib/python2.7/site-packages/redisearch/__init__.py
/usr/lib/python2.7/site-packages/redisearch/_util.py
/usr/lib/python2.7/site-packages/redisearch/auto_complete.py
/usr/lib/python2.7/site-packages/redisearch/client.py
/usr/lib/python2.7/site-packages/redisearch/document.py
/usr/lib/python2.7/site-packages/redisearch/query.py
/usr/lib/python2.7/site-packages/redisearch/result.py
/usr/lib/python2.7/site-packages/rmtest/__init__.py
/usr/lib/python2.7/site-packages/rmtest/cluster.py
/usr/lib/python2.7/site-packages/rmtest/disposableredis/__init__.py
/usr/lib/python2.7/site-packages/rmtest/disposableredis/cluster.py
```

Delete rmtest from install_requires can fix this issue.