### PR TITLE
feat: Add 'alter schema add' support

### DIFF
--- a/API.md
+++ b/API.md
@@ -195,6 +195,41 @@ Add a single document to the index.
              NOTE: Geo points shoule be encoded as strings of "lon,lat"
 
 
+### aggregate
+```py
+
+def aggregate(self, query)
+
+```
+
+
+
+Issue an aggregation query
+
+### Parameters
+
+**query**: This can be either an `AggeregateRequest`, or a `Cursor`
+
+An `AggregateResult` object is returned. You can access the rows from its
+`rows` property, which will always yield the rows of the result
+
+
+### alter\_schema\_add
+```py
+
+def alter_schema_add(self, fields)
+
+```
+
+
+
+Alter the existing search index by adding new fields. The index must already exist.
+
+### Parameters:
+
+- **fields**: a list of Field objects to add for the index
+
+
 ### batch\_indexer
 ```py
 

--- a/redisearch/client.py
+++ b/redisearch/client.py
@@ -102,6 +102,7 @@ class Client(object):
     NUMERIC = 'NUMERIC'
 
     CREATE_CMD = 'FT.CREATE'
+    ALTER_CMD = 'FT.ALTER'
     SEARCH_CMD = 'FT.SEARCH'
     ADD_CMD = 'FT.ADD'
     DROP_CMD = 'FT.DROP'
@@ -195,6 +196,21 @@ class Client(object):
                 args += list(stopwords)
     
         args.append('SCHEMA')
+
+        args += list(itertools.chain(*(f.redis_args() for f in fields)))
+
+        return self.redis.execute_command(*args)
+
+    def alter_schema_add(self, fields):
+        """
+        Alter the existing search index by adding new fields. The index must already exist.
+
+        ### Parameters:
+
+        - **fields**: a list of Field objects to add for the index
+        """
+
+        args = [self.ALTER_CMD, self.index_name, 'SCHEMA', 'ADD']
 
         args += list(itertools.chain(*(f.redis_args() for f in fields)))
 

--- a/test/test.py
+++ b/test/test.py
@@ -494,6 +494,31 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
                 res = client.search(q)
                 self.assertEqual(1, res.total)
 
+    def testAlterSchemaAdd(self):
+        conn = self.redis()
+
+        with conn as r:
+            # Creating a client with a given index name
+            client = Client('alterIdx', port=conn.port)
+            client.redis.flushdb()
+
+            # Creating the index definition and schema
+            client.create_index((TextField('title'),))
+
+            # Using alter to add a field
+            client.alter_schema_add((TextField('body'),))
+
+            # Indexing a document
+            client.add_document('doc1', title = 'MyTitle', body = 'Some content only in the body')
+
+            # Searching with parameter only in the body (the added field)
+            q = Query("only in the body")
+
+            # Ensure we find the result searching on the added body field
+            res = client.search(q)
+            self.assertEqual(1, res.total)
+
+
 if __name__ == '__main__':
 
     unittest.main()


### PR DESCRIPTION
This adds 'ALTER SCHEMA ADD' support to the client as per https://oss.redislabs.com/redisearch/Commands.html#ftalter_schema_add

Test included

Also would allow the use-case of #13 with an alter command