### PR TITLE
[fix] fixes APPLY / SORTBY / GROUPBY / REDUCE order on FT.AGGREGATE s…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,13 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
-            REDIS_PORT=6379 python test/test.py 
+            REDIS_PORT=6379 python test/test.py
+
+      - run:
+          name: run query builder tests
+          command: |
+            . venv/bin/activate
+            python test/test.py
 
       # no need for store_artifacts on nightly builds 
 

--- a/redisearch/aggregation.py
+++ b/redisearch/aggregation.py
@@ -113,14 +113,14 @@ class Projection(object):
     This object automatically created in the `AggregateRequest.apply()`
     """
 
-    def __init__(self, alias, projector):
+    def __init__(self, projector, alias=None ):
 
         self.alias = alias
         self.projector = projector
 
     def build_args(self):
         ret = ['APPLY', self.projector]
-        if self.alias:
+        if self.alias is not None:
             ret += ['AS', self.alias]
 
         return ret
@@ -130,7 +130,7 @@ class SortBy(object):
     This object automatically created in the `AggregateRequest.sort_by()`
     """
 
-    def __init__(self, fields, max):
+    def __init__(self, fields, max=0):
         self.fields = fields
         self.max = max
 

--- a/redisearch/aggregation.py
+++ b/redisearch/aggregation.py
@@ -99,13 +99,56 @@ class Group(object):
         self.limit = Limit()
 
     def build_args(self):
-        ret = [str(len(self.fields))]
+        ret = ['GROUPBY', str(len(self.fields))]
         ret.extend(self.fields)
         for reducer in self.reducers:
             ret += ['REDUCE', reducer.NAME, str(len(reducer.args))]
             ret.extend(reducer.args)
             if reducer._alias:
                 ret += ['AS', reducer._alias]
+        return ret
+
+class Projection(object):
+    """
+    This object automatically created in the `AggregateRequest.apply()`
+    """
+
+    def __init__(self, alias, projector):
+
+        self.alias = alias
+        self.projector = projector
+
+    def build_args(self):
+        ret = ['APPLY', self.projector]
+        if self.alias:
+            ret += ['AS', self.alias]
+
+        return ret
+
+class SortBy(object):
+    """
+    This object automatically created in the `AggregateRequest.sort_by()`
+    """
+
+    def __init__(self, fields, max):
+        self.fields = fields
+        self.max = max
+
+
+
+    def build_args(self):
+        fields_args = []
+        for f in self.fields:
+            if isinstance(f, SortDirection):
+                fields_args += [f.field, f.DIRSTRING]
+            else:
+                fields_args += [f]
+
+        ret = ['SORTBY', str(len(fields_args))]
+        ret.extend(fields_args)
+        if self.max > 0:
+            ret += ['MAX', str(self.max)]
+
         return ret
 
 
@@ -127,11 +170,9 @@ class AggregateRequest(object):
         return the object itself, making them useful for chaining.
         """
         self._query = query
-        self._groups = []
-        self._projections = []
+        self._aggregateplan = []
         self._loadfields = []
         self._limit = Limit()
-        self._sortby = []
         self._max = 0
         self._with_schema = False
         self._verbatim = False
@@ -162,7 +203,7 @@ class AggregateRequest(object):
             `aggregation` module.
         """
         group = Group(fields, reducers)
-        self._groups.append(group)
+        self._aggregateplan.extend(group.build_args())
 
         return self
 
@@ -177,7 +218,8 @@ class AggregateRequest(object):
             expression itself, for example `apply(square_root="sqrt(@foo)")`
         """
         for alias, expr in kwexpr.items():
-            self._projections.append([alias, expr])
+            projection = Projection(alias, expr)
+            self._aggregateplan.extend(projection.build_args())
 
         return self
 
@@ -224,10 +266,7 @@ class AggregateRequest(object):
 
         """
         limit = Limit(offset, num)
-        if self._groups:
-            self._groups[-1].limit = limit
-        else:
-            self._limit = limit
+        self._limit = limit
         return self
 
     def sort_by(self, *fields, **kwargs):
@@ -258,14 +297,13 @@ class AggregateRequest(object):
             .sort_by(Desc('@paid'), max=10)
         ```
         """
-        self._max = kwargs.get('max', 0)
         if isinstance(fields, (string_types, SortDirection)):
             fields = [fields]
-        for f in fields:
-            if isinstance(f, SortDirection):
-                self._sortby += [f.field, f.DIRSTRING]
-            else:
-                self._sortby.append(f)
+
+        max = kwargs.get('max', 0)
+        sortby = SortBy(fields, max)
+
+        self._aggregateplan.extend(sortby.build_args())
         return self
 
     def with_schema(self):
@@ -312,18 +350,8 @@ class AggregateRequest(object):
             ret.append('LOAD')
             ret.append(str(len(self._loadfields)))
             ret.extend(self._loadfields)
-        for group in self._groups:
-            ret += ['GROUPBY'] + group.build_args() + group.limit.build_args()
-        for alias, projector in self._projections:
-            ret += ['APPLY', projector]
-            if alias:
-                ret += ['AS', alias]
 
-        if self._sortby:
-            ret += ['SORTBY', str(len(self._sortby))]
-            ret += self._sortby
-            if self._max:
-                ret += ['MAX', str(self._max)]
+        ret.extend(self._aggregateplan)
 
         ret += self._limit.build_args()
 

--- a/redisearch/aggregation.py
+++ b/redisearch/aggregation.py
@@ -172,7 +172,6 @@ class AggregateRequest(object):
         self._query = query
         self._aggregateplan = []
         self._loadfields = []
-        self._filters = []
         self._limit = Limit()
         self._max = 0
         self._with_schema = False
@@ -319,9 +318,12 @@ class AggregateRequest(object):
         if isinstance(expressions, (string_types)):
             expressions = [expressions]
 
-        self._filters.extend(expressions)
+        for expression in expressions:
+            self._aggregateplan.extend(['FILTER', expression])
 
         return self
+
+
 
     def with_schema(self):
         """
@@ -369,10 +371,6 @@ class AggregateRequest(object):
             ret.extend(self._loadfields)
 
         ret.extend(self._aggregateplan)
-
-        for expr in self._filters:
-            ret.append('FILTER')
-            ret.append(expr)
 
         ret += self._limit.build_args()
 

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -62,6 +62,10 @@ class QueryBuilderTest(unittest.TestCase):
         req = a.AggregateRequest().group_by('@foo', r.count())
         self.assertEqual(['*', 'GROUPBY', '1', '@foo', 'REDUCE', 'COUNT', '0'], req.build_args())
 
+        # Test with group_by and alias on reducer
+        req = a.AggregateRequest().group_by('@foo', r.count().alias('foo_count'))
+        self.assertEqual(['*', 'GROUPBY', '1', '@foo', 'REDUCE', 'COUNT', '0', 'AS', 'foo_count'], req.build_args())
+
         # Test with limit
         req = a.AggregateRequest(). \
             group_by('@foo', r.count()). \
@@ -76,6 +80,10 @@ class QueryBuilderTest(unittest.TestCase):
 
         self.assertEqual(['*', 'APPLY', '@bar / 2', 'AS', 'foo', 'GROUPBY', '1', '@foo', 'REDUCE', 'COUNT', '0'],
                          req.build_args())
+
+        # Test with filter
+        req = a.AggregateRequest().group_by('@foo', r.count()).filter( "@foo=='bar'")
+        self.assertEqual(['*', 'GROUPBY', '1', '@foo', 'REDUCE', 'COUNT', '0', 'FILTER', "@foo=='bar'" ], req.build_args())
 
         # Test with sort_by
         req = a.AggregateRequest().group_by('@foo', r.count()).sort_by('@date')

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -85,6 +85,15 @@ class QueryBuilderTest(unittest.TestCase):
         req = a.AggregateRequest().group_by('@foo', r.count()).filter( "@foo=='bar'")
         self.assertEqual(['*', 'GROUPBY', '1', '@foo', 'REDUCE', 'COUNT', '0', 'FILTER', "@foo=='bar'" ], req.build_args())
 
+        # Test with filter on different state of the pipeline
+        req = a.AggregateRequest().filter("@foo=='bar'").group_by('@foo', r.count())
+        self.assertEqual(['*', 'FILTER', "@foo=='bar'", 'GROUPBY', '1', '@foo','REDUCE', 'COUNT', '0' ], req.build_args())
+
+        # Test with filter on different state of the pipeline
+        req = a.AggregateRequest().filter(["@foo=='bar'","@foo2=='bar2'"]).group_by('@foo', r.count())
+        self.assertEqual(['*', 'FILTER', "@foo=='bar'", 'FILTER', "@foo2=='bar2'", 'GROUPBY', '1', '@foo', 'REDUCE', 'COUNT', '0'],
+                         req.build_args())
+
         # Test with sort_by
         req = a.AggregateRequest().group_by('@foo', r.count()).sort_by('@date')
         # print req.build_args()


### PR DESCRIPTION
This is a draft PR open for discussion, fixing AggregateRequest incorrect order of clauses.

Fixes #40 

Overall changes:
- [add] added query builder tests to circleci
- [add] added # Test with apply testcase to `testbuilder.py`
- [fix] fixed  `Single field, single reducer`, `Multiple fields, single reducer`, and `Multiple fields, multiple reducers` testcases on `testbuilder.py`
- [rem] removed `self._groups = []`,  `self._projections = []` and `self._sortby = []` in exchange of `self._aggregateplan = []` which enforces the order of the clauses to be the order of the method calls. 

@stryt2, would appreciate your comments regarding the changes. 
