### PR TITLE
Fix TextField Sortable/Nostem bug

### DIFF
--- a/redisearch/client.py
+++ b/redisearch/client.py
@@ -39,10 +39,10 @@ class TextField(Field):
     def __init__(self, name, weight=1.0, sortable=False, no_stem=False,
                  no_index=False):
         args = [Field.TEXT, Field.WEIGHT, weight]
-        if sortable:
-            args.append(Field.SORTABLE)
         if no_stem:
             args.append(self.NOSTEM)
+        if sortable:
+            args.append(Field.SORTABLE)
         if no_index:
             args.append(self.NOINDEX)
 

--- a/test/test.py
+++ b/test/test.py
@@ -494,6 +494,22 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
                 res = client.search(q)
                 self.assertEqual(1, res.total)
 
+    def testTextFieldSortableNostem(self):
+        conn = self.redis()
+
+        with conn as r:
+            # Creating a client with a given index name
+            client = Client('sortableNostem', port=conn.port)
+            client.redis.flushdb()
+
+            # Creating the index definition with sortable and no_stem
+            client.create_index((TextField('txt', sortable=True, no_stem=True),))
+
+            # Now get the index info to confirm its contents
+            response = client.info()
+            self.assertIn(b'SORTABLE', response['fields'][0])
+            self.assertIn(b'NOSTEM', response['fields'][0])
+
 if __name__ == '__main__':
 
     unittest.main()


### PR DESCRIPTION
Fixes #31 

Tests included

Before:
```
Traceback (most recent call last):
  File "test.py", line 5, in <module>
    r.create_index([field])
  File "/usr/local/lib/python3.7/dist-packages/redisearch/client.py", line 198, in create_index
    return self.redis.execute_command(*args)
  File "/usr/local/lib/python3.7/dist-packages/redis/client.py", line 839, in execute_command
    return self.parse_response(conn, command_name, **options)
  File "/usr/local/lib/python3.7/dist-packages/redis/client.py", line 853, in parse_response
    response = connection.read_response()
  File "/usr/local/lib/python3.7/dist-packages/redis/connection.py", line 718, in read_response
    raise response
redis.exceptions.ResponseError: Could not parse field spec
```

After:
```
{'index_name': 'test', 'index_options': [], 'fields': [[b'test', b'type', b'TEXT', b'WEIGHT', b'1', b'SORTABLE', b'NOSTEM']], 'num_docs': '0', 'max_doc_id': '0', 'num_terms': '0', 'num_records': '0', 'inverted_sz_mb': '0', 'offset_vectors_sz_mb': '0', 'doc_table_size_mb': '0', 'sortable_values_size_mb': '0', 'key_table_size_mb': '1.239776611328125e-05', 'records_per_doc_avg': '-nan', 'bytes_per_record_avg': '-nan', 'offsets_per_term_avg': '-nan', 'offset_bits_per_record_avg': '-nan', 'gc_stats': [b'current_hz', b'10', b'bytes_collected', b'0', b'effectiv_cycles_rate', b'0'], 'cursor_stats': [b'global_idle', 0, b'global_total', 0, b'index_capacity', 128, b'index_total', 0]}
```

test.py used above for reference:
```
import redisearch

r = redisearch.Client("test")
field = redisearch.TextField("test", sortable=True, no_stem=True)
r.create_index([field])
print(r.info())
```