### PR TITLE
Fix - NameError: name 'long' is not defined

### DIFF
--- a/redisearch/client.py
+++ b/redisearch/client.py
@@ -1,4 +1,5 @@
 from redis import Redis, RedisError, ConnectionPool
+from redis._compat import long
 import itertools
 import time
 import six


### PR DESCRIPTION
See https://github.com/RediSearch/redisearch-py/issues/64