### PR TITLE
enable FT.TAGVALS command

### DIFF
--- a/redisearch/client.py
+++ b/redisearch/client.py
@@ -174,6 +174,7 @@ class Client(object):
     GET_CMD = 'FT.GET'
     MGET_CMD = 'FT.MGET'
     CONFIG_CMD = 'FT.CONFIG'
+    TAGVALS_CMD = 'FT.TAGVALS'
 
     NOOFFSETS = 'NOOFFSETS'
     NOFIELDS = 'NOFIELDS'
@@ -648,3 +649,16 @@ class Client(object):
             for kvs in raw:
                 res[kvs[0]] = kvs[1]
         return res
+
+    def tagvals(self, tagfield):
+        """
+        Return a list of all possible tag values
+
+        ### Parameters
+
+        - **field**: Tag field name
+        """
+
+        cmd = self.redis.execute_command(self.TAGVALS_CMD, self.index_name, tagfield)
+        return cmd
+

--- a/redisearch/client.py
+++ b/redisearch/client.py
@@ -656,7 +656,7 @@ class Client(object):
 
         ### Parameters
 
-        - **field**: Tag field name
+        - **tagfield**: Tag field name
         """
 
         cmd = self.redis.execute_command(self.TAGVALS_CMD, self.index_name, tagfield)

--- a/test/test.py
+++ b/test/test.py
@@ -596,8 +596,10 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
             client.redis.flushdb()
             
             client.create_index((TextField('txt'), TagField('tags')))
+            
+            tags = 'foo,foo bar,hello;world'
 
-            client.add_document('doc1', txt = 'fooz barz', tags = 'foo,foo bar,hello;world')
+            client.add_document('doc1', txt = 'fooz barz', tags = tags)
             
             for i in r.retry_with_rdb_reload():
                 waitForIndex(r, 'idx')
@@ -616,6 +618,11 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
                 q = Query("@tags:{hello\\;world}")
                 res = client.search(q)
                 self.assertEqual(1, res.total)
+
+                q2 = client.tagvals('tags')
+                self.assertEqual(tags.split(','), q2)
+
+
 
     def testTextFieldSortableNostem(self):
         conn = self.redis()

--- a/test/test.py
+++ b/test/test.py
@@ -597,9 +597,11 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
             
             client.create_index((TextField('txt'), TagField('tags')))
             
-            tags = 'foo,foo bar,hello;world'
+            tags  = 'foo,foo bar,hello;world'
+            tags2 = 'soba,ramen'
 
             client.add_document('doc1', txt = 'fooz barz', tags = tags)
+            client.add_document('doc2', txt = 'noodles', tags = tags2)
             
             for i in r.retry_with_rdb_reload():
                 waitForIndex(r, 'idx')
@@ -620,9 +622,7 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
                 self.assertEqual(1, res.total)
 
                 q2 = client.tagvals('tags')
-                self.assertEqual(tags.split(','), q2)
-
-
+                self.assertEqual(tags.split(',') + tags2.split(','), q2)
 
     def testTextFieldSortableNostem(self):
         conn = self.redis()


### PR DESCRIPTION
add a new function to client which takes the name of a tagfield and runs the following command

```
FT.TAGVAL <INDEX> tagfield
```

Returning a list of tags.

Test is included in test/test.py