### PR TITLE
add keep_docs to drop_index

### DIFF
--- a/redisearch/client.py
+++ b/redisearch/client.py
@@ -301,7 +301,20 @@ class Client(object):
 
     def drop_index(self, delete_documents=True):
         """
+        Drop the index if it exists. Deprecated from RediSearch 2.0.
+
+        ### Parameters:
+
+        - **delete_documents**: If `True`, all documents will be deleted.
+        """
+        keep_str = '' if delete_documents else 'KEEPDOCS'
+        return self.redis.execute_command(self.DROP_CMD, self.index_name, keep_str)
+
+    def dropindex(self, delete_documents=False):
+        """
         Drop the index if it exists.
+        Replaced `drop_index` in RediSearch 2.0.
+        Default behavior was changed to not delete the indexed documents. 
 
         ### Parameters:
 

--- a/redisearch/client.py
+++ b/redisearch/client.py
@@ -161,8 +161,7 @@ class Client(object):
     SEARCH_CMD = 'FT.SEARCH'
     ADD_CMD = 'FT.ADD'
     ADDHASH_CMD = "FT.ADDHASH"
-    # DROP_CMD = 'FT.DROP' - deprecated
-    DROPINDEX_CMD = 'FT.DROPINDEX'
+    DROP_CMD = 'FT.DROP'
     EXPLAIN_CMD = 'FT.EXPLAIN'
     DEL_CMD = 'FT.DEL'
     AGGREGATE_CMD = 'FT.AGGREGATE'
@@ -308,8 +307,8 @@ class Client(object):
 
         - **delete_documents**: If `True`, all documents will be deleted.
         """
-        delete_str = 'DD' if delete_documents else ''
-        return self.redis.execute_command(self.DROPINDEX_CMD, self.index_name, delete_str)
+        keep_str = '' if delete_documents else 'KEEPDOCS'
+        return self.redis.execute_command(self.DROP_CMD, self.index_name, keep_str)
 
     def _add_document(self, doc_id, conn=None, nosave=False, score=1.0, payload=None,
                       replace=False, partial=False, language=None, no_create=False, **fields):

--- a/redisearch/client.py
+++ b/redisearch/client.py
@@ -161,7 +161,8 @@ class Client(object):
     SEARCH_CMD = 'FT.SEARCH'
     ADD_CMD = 'FT.ADD'
     ADDHASH_CMD = "FT.ADDHASH"
-    DROP_CMD = 'FT.DROP'
+    # DROP_CMD = 'FT.DROP' - deprecated
+    DROPINDEX_CMD = 'FT.DROPINDEX'
     EXPLAIN_CMD = 'FT.EXPLAIN'
     DEL_CMD = 'FT.DEL'
     AGGREGATE_CMD = 'FT.AGGREGATE'
@@ -299,16 +300,16 @@ class Client(object):
 
         return self.redis.execute_command(*args)
 
-    def drop_index(self, keep_documents=False):
+    def drop_index(self, delete_documents=True):
         """
         Drop the index if it exists.
 
         ### Parameters:
 
-        - **keep_documents**: If `True`, all documents will be deleted.
+        - **delete_documents**: If `True`, all documents will be deleted.
         """
-        keep_str = 'KEEPDOCS' if keep_documents else ''
-        return self.redis.execute_command(self.DROP_CMD, self.index_name, keep_str)
+        delete_str = 'DD' if delete_documents else ''
+        return self.redis.execute_command(self.DROPINDEX_CMD, self.index_name, delete_str)
 
     def _add_document(self, doc_id, conn=None, nosave=False, score=1.0, payload=None,
                       replace=False, partial=False, language=None, no_create=False, **fields):

--- a/redisearch/client.py
+++ b/redisearch/client.py
@@ -299,11 +299,16 @@ class Client(object):
 
         return self.redis.execute_command(*args)
 
-    def drop_index(self):
+    def drop_index(self, keep_documents=False):
         """
-        Drop the index if it exists
+        Drop the index if it exists.
+
+        ### Parameters:
+
+        - **keep_documents**: If `True`, all documents will be deleted.
         """
-        return self.redis.execute_command(self.DROP_CMD, self.index_name)
+        keep_str = 'KEEPDOCS' if keep_documents else ''
+        return self.redis.execute_command(self.DROP_CMD, self.index_name, keep_str)
 
     def _add_document(self, doc_id, conn=None, nosave=False, score=1.0, payload=None,
                       replace=False, partial=False, language=None, no_create=False, **fields):

--- a/test/test.py
+++ b/test/test.py
@@ -391,6 +391,40 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
             self.assertEqual('doc2', res2.docs[1].id)
             self.assertEqual('doc3', res2.docs[0].id)
 
+    def testDropIndex(self):
+        """
+        Ensure the index gets dropped by data remains by default
+        """
+        for x in range(200):
+            print("Run ", x)
+            conn = self.redis()
+            with conn as r:
+                if check_version(r, 20000):
+                    idx = "HaveIt-%d" %(int(time.time()))
+                    index = Client(idx, port=conn.port)
+                    index.redis.hset("index:haveit", mapping = {'name': 'haveit'})
+                    idef = IndexDefinition(prefix=['index:'])
+                    index.create_index((TextField('name'),),definition=idef)
+                    waitForIndex(index.redis, idx)
+                    index.drop_index(keep_documents=True)
+                    i = index.redis.hgetall("index:haveit")
+                    self.assertEqual(i, {'name': 'haveit'})
+
+        for x in range(200):
+            print("Run ", x)
+            conn = self.redis()
+            with conn as r:
+                if check_version(r, 20000):
+                    idx = "HaveIt-%d" %(int(time.time()))
+                    index = Client(idx, port=conn.port)
+                    index.redis.hset("index:haveit", mapping = {'name': 'haveit'})
+                    idef = IndexDefinition(prefix=['index:'])
+                    index.create_index((TextField('name'),),definition=idef)
+                    waitForIndex(index.redis, idx)
+                    index.drop_index()
+                    i = index.redis.hgetall("index:haveit")
+                    self.assertEqual(i, {})
+
     def testExample(self):
         conn = self.redis()
 
@@ -922,7 +956,6 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
 
             info = client.info()
             self.assertEqual(495, int(info['num_docs']))
-
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test.py
+++ b/test/test.py
@@ -395,35 +395,20 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
         """
         Ensure the index gets dropped by data remains by default
         """
-        for x in range(200):
-            print("Run ", x)
+        for x in range(20):
             conn = self.redis()
             with conn as r:
                 if check_version(r, 20000):
-                    idx = "HaveIt-%d" %(int(time.time()))
-                    index = Client(idx, port=conn.port)
-                    index.redis.hset("index:haveit", mapping = {'name': 'haveit'})
-                    idef = IndexDefinition(prefix=['index:'])
-                    index.create_index((TextField('name'),),definition=idef)
-                    waitForIndex(index.redis, idx)
-                    index.drop_index(keep_documents=True)
-                    i = index.redis.hgetall("index:haveit")
-                    self.assertEqual(i, {'name': 'haveit'})
-
-        for x in range(200):
-            print("Run ", x)
-            conn = self.redis()
-            with conn as r:
-                if check_version(r, 20000):
-                    idx = "HaveIt-%d" %(int(time.time()))
-                    index = Client(idx, port=conn.port)
-                    index.redis.hset("index:haveit", mapping = {'name': 'haveit'})
-                    idef = IndexDefinition(prefix=['index:'])
-                    index.create_index((TextField('name'),),definition=idef)
-                    waitForIndex(index.redis, idx)
-                    index.drop_index()
-                    i = index.redis.hgetall("index:haveit")
-                    self.assertEqual(i, {})
+                    for keep_docs in [[ True , {'name': 'haveit'} ], [ False , {} ]]:
+                        idx = "HaveIt-%d" %(int(time.time()))
+                        index = Client(idx, port=conn.port)
+                        index.redis.hset("index:haveit", mapping = {'name': 'haveit'})
+                        idef = IndexDefinition(prefix=['index:'])
+                        index.create_index((TextField('name'),),definition=idef)
+                        waitForIndex(index.redis, idx)
+                        index.drop_index(keep_documents=keep_docs[0])
+                        i = index.redis.hgetall("index:haveit")
+                        self.assertEqual(i, keep_docs[1])
 
     def testExample(self):
         conn = self.redis()

--- a/test/test.py
+++ b/test/test.py
@@ -400,7 +400,7 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
             with conn as r:
                 if check_version(r, 20000):
                     for keep_docs in [[ True , {} ], [ False , {'name': 'haveit'} ]]:
-                        idx = "HaveIt-%d" %(int(time.time()))
+                        idx = "HaveIt"
                         index = Client(idx, port=conn.port)
                         index.redis.hset("index:haveit", mapping = {'name': 'haveit'})
                         idef = IndexDefinition(prefix=['index:'])

--- a/test/test.py
+++ b/test/test.py
@@ -399,14 +399,14 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
             conn = self.redis()
             with conn as r:
                 if check_version(r, 20000):
-                    for keep_docs in [[ True , {'name': 'haveit'} ], [ False , {} ]]:
+                    for keep_docs in [[ True , {} ], [ False , {'name': 'haveit'} ]]:
                         idx = "HaveIt-%d" %(int(time.time()))
                         index = Client(idx, port=conn.port)
                         index.redis.hset("index:haveit", mapping = {'name': 'haveit'})
                         idef = IndexDefinition(prefix=['index:'])
                         index.create_index((TextField('name'),),definition=idef)
                         waitForIndex(index.redis, idx)
-                        index.drop_index(keep_documents=keep_docs[0])
+                        index.drop_index(delete_documents=keep_docs[0])
                         i = index.redis.hgetall("index:haveit")
                         self.assertEqual(i, keep_docs[1])
 

--- a/test/test.py
+++ b/test/test.py
@@ -57,7 +57,7 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
                                 TextField('txt'), 
                                 NumericField('chapter')), definition=definition)
         except redis.ResponseError:
-            client.drop_index()
+            client.dropindex(delete_documents=True)
             return self.createIndex(client, num_docs=num_docs, definition=definition)
 
         chapters = {}
@@ -193,7 +193,7 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
         """
         client = Client(name, port=self.server.port)
         try:
-            client.drop_index()
+            client.dropindex(delete_documents=True)
         except:
             pass
 
@@ -406,7 +406,7 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
                         idef = IndexDefinition(prefix=['index:'])
                         index.create_index((TextField('name'),),definition=idef)
                         waitForIndex(index.redis, idx)
-                        index.drop_index(delete_documents=keep_docs[0])
+                        index.dropindex(delete_documents=keep_docs[0])
                         i = index.redis.hgetall("index:haveit")
                         self.assertEqual(i, keep_docs[1])
 


### PR DESCRIPTION
fix #107 

We should decide on a default behavior of removal of documents. 
* Remove - like `FT.DROP`
* Keep - like `FT.DROPINDEX`