### PR TITLE
Add Scorer option to Query

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,6 @@ fabric.properties
 
 # Android studio 3.1+ serialized cache file
 .idea/caches/build_file_checksums.ser
+
+# Dependencies
+deps/*

--- a/redisearch/query.py
+++ b/redisearch/query.py
@@ -5,13 +5,13 @@ class Query(object):
     Query is used to build complex queries that have more parameters than just the query string.
     The query string is set in the constructor, and other options have setter functions.
 
-    The setter functions return the query object, so they can be chained, 
+    The setter functions return the query object, so they can be chained,
     i.e. `Query("foo").verbatim().filter(...)` etc.
     """
 
     def __init__(self, query_string):
         """
-        Create a new query object. 
+        Create a new query object.
         The query string is set in the constructor, and other options have setter functions.
         """
 
@@ -24,6 +24,7 @@ class Query(object):
         self._verbatim = False
         self._with_payloads = False
         self._with_scores = False
+        self._scorer = False
         self._filters = list()
         self._ids = None
         self._slop = -1
@@ -129,6 +130,14 @@ class Query(object):
         self._in_order = True
         return self
 
+    def scorer(self, scorer):
+        """
+        Use a different scoring function to evaluate document relevance. Default is `TFIDF`
+        :param scorer: The scoring function to use (e.g. `TFIDF.DOCNORM` or `BM25`)
+        """
+        self._scorer = scorer
+        return self
+
     def get_args(self):
         """
         Format the redis arguments for this query and return them
@@ -144,7 +153,7 @@ class Query(object):
             args.append('INFIELDS')
             args.append(len(self._fields))
             args += self._fields
-        
+
         if self._verbatim:
             args.append('VERBATIM')
 
@@ -159,9 +168,12 @@ class Query(object):
         if self._with_payloads:
             args.append('WITHPAYLOADS')
 
+        if self._scorer:
+            args += ['SCORER', self._scorer]
+
         if self._with_scores:
             args.append('WITHSCORES')
-        
+
         if self._ids:
             args.append('INKEYS')
             args.append(len(self._ids))
@@ -217,7 +229,7 @@ class Query(object):
 
     def no_stopwords(self):
         """
-        Prevent the query from being filtered for stopwords. 
+        Prevent the query from being filtered for stopwords.
         Only useful in very big queries that you are certain contain no stopwords.
         """
         self._no_stopwords = True
@@ -236,7 +248,7 @@ class Query(object):
         """
         self._with_scores = True
         return self
-    
+
     def limit_fields(self, *fields):
         """
         Limit the search to specific TEXT fields only
@@ -248,7 +260,7 @@ class Query(object):
 
     def add_filter(self, flt):
         """
-        Add a numeric or geo filter to the query. 
+        Add a numeric or geo filter to the query.
         **Currently only one of each filter is supported by the engine**
 
         - **flt**: A NumericFilter or GeoFilter object, used on a corresponding field
@@ -273,7 +285,7 @@ class Filter(object):
     def __init__(self, keyword, field, *args):
 
         self.args = [keyword, field] + list(args)
-        
+
 class NumericFilter(Filter):
 
     INF = '+inf'

--- a/test/test.py
+++ b/test/test.py
@@ -53,8 +53,8 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
 
         assert isinstance(client, Client)
         try:
-            client.create_index((TextField('play', weight=5.0), 
-                                TextField('txt'), 
+            client.create_index((TextField('play', weight=5.0),
+                                TextField('txt'),
                                 NumericField('chapter')), definition=definition)
         except redis.ResponseError:
             client.drop_index()
@@ -161,7 +161,7 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
                 self.assertEqual(len(subset), docs.total)
                 ids = [x.id for x in docs.docs]
                 self.assertEqual(set(ids), set(subset))
- 
+
 #                 self.assertRaises(redis.ResponseError, client.search, Query('henry king').return_fields('play', 'nonexist'))
 
                 # test slop and in order
@@ -272,7 +272,7 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
             #self.assertEqual(0.2, res.docs[1].score)
 
     def testReplace(self):
-        
+
         conn = self.redis()
 
         with conn as r:
@@ -296,7 +296,7 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
             self.assertEqual(1, res.total)
             self.assertEqual('doc1', res.docs[0].id)
 
-    def testStopwords(self): 
+    def testStopwords(self):
         # Creating a client with a given index name
         client = self.getCleanClient('idx')
 
@@ -324,7 +324,7 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
 
             for i in r.retry_with_rdb_reload():
                 waitForIndex(r, 'idx')
-                # Test numerical filter     
+                # Test numerical filter
                 q1 = Query("foo").add_filter(NumericFilter('num', 0, 2)).no_content()
                 q2 = Query("foo").add_filter(NumericFilter('num', 2, NumericFilter.INF, minExclusive=True)).no_content()
                 res1, res2 =  client.search(q1), client.search(q2)
@@ -338,11 +338,11 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
                 q1 = Query("foo").add_filter(GeoFilter('loc', -0.44, 51.45, 10)).no_content()
                 q2 = Query("foo").add_filter(GeoFilter('loc', -0.44, 51.45, 100)).no_content()
                 res1, res2 =  client.search(q1), client.search(q2)
-                
+
                 self.assertEqual(1, res1.total)
                 self.assertEqual(2, res2.total)
                 self.assertEqual('doc1', res1.docs[0].id)
-                
+
                 # Sort results, after RDB reload order may change
                 list = [res2.docs[0].id, res2.docs[1].id]
                 list.sort()
@@ -371,7 +371,7 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
             # Creating a client with a given index name
             client = Client('idx', port=conn.port)
             client.redis.flushdb()
-            
+
             client.create_index((TextField('txt'), NumericField('num', sortable=True)))
             client.add_document('doc1', txt = 'foo bar', num = 1)
             client.add_document('doc2', txt = 'foo baz', num = 2)
@@ -381,7 +381,7 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
             q1 = Query("foo").sort_by('num', asc=True).no_content()
             q2 = Query("foo").sort_by('num', asc=False).no_content()
             res1, res2 = client.search(q1), client.search(q2)
-            
+
             self.assertEqual(3, res1.total)
             self.assertEqual('doc1', res1.docs[0].id)
             self.assertEqual('doc2', res1.docs[1].id)
@@ -398,7 +398,7 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
             # Creating a client with a given index name
             client = Client('myIndex', port=conn.port)
             client.redis.flushdb()
-            
+
             # Creating the index definition and schema
             client.create_index((TextField('title', weight=5.0), TextField('body')))
 
@@ -533,7 +533,7 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
             # values
             res = client.search('@f3:f3_val @f2:f2_val @f1:f1_val')
             self.assertEqual(1, res.total)
-            
+
         with self.assertRaises(redis.ResponseError) as error:
             client.add_document('doc3', f2='f2_val', f3='f3_val', no_create=True)
 
@@ -559,7 +559,7 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
                             doc.txt)
 
             q = Query('king henry').paging(0, 1).summarize().highlight()
-            
+
             doc = sorted(client.search(q).docs)[0]
             self.assertEqual('<b>Henry</b> ... ', doc.play)
             self.assertEqual('ACT I SCENE I. London. The palace. Enter <b>KING</b> <b>HENRY</b>, LORD JOHN OF LANCASTER, the EARL of WESTMORELAND, SIR... ',
@@ -581,7 +581,7 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
 
                 def1 =IndexDefinition(prefix=['index1:'],score_field='name')
                 def2 =IndexDefinition(prefix=['index2:'],score_field='name')
-                
+
                 index1.create_index((TextField('name'),),definition=def1)
                 index2.create_index((TextField('name'),),definition=def2)
 
@@ -609,7 +609,7 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
                 with self.assertRaises(Exception) as context:
                     alias_client2.search('*').docs[0]
                 self.assertEqual('spaceballs: no such index', str(context.exception))
-                
+
             else:
 
                 # Creating a client with one index
@@ -788,6 +788,22 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
             res = client.search(Query("Jon"))
             self.assertEqual(2, len(res.docs))
             self.assertEqual(['John', 'Jon'], sorted([d.name for d in res.docs]))
+
+    def testScorer(self):
+        # Creating a client with a given index name
+        client = self.getCleanClient('idx')
+
+        client.create_index((TextField('description'),))
+
+        client.add_document('doc1', description='The quick brown fox jumps over the lazy dog')
+        client.add_document('doc2', description='Quick alice was beginning to get very tired of sitting by her quick sister on the bank, and of having nothing to do.')
+
+        # default scorer is TFIDF
+        res = client.search(Query('quick'))
+        self.assertEqual('doc2', res.docs[0].id)
+
+        res = client.search(Query('quick').scorer('TFIDF.DOCNORM'))
+        self.assertEqual('doc1', res.docs[0].id)
 
     def testGet(self):
         client = self.getCleanClient('idx')

--- a/test/test.py
+++ b/test/test.py
@@ -799,11 +799,25 @@ class RedisSearchTestCase(ModuleTestCase('../module.so')):
         client.add_document('doc2', description='Quick alice was beginning to get very tired of sitting by her quick sister on the bank, and of having nothing to do.')
 
         # default scorer is TFIDF
-        res = client.search(Query('quick'))
-        self.assertEqual('doc2', res.docs[0].id)
+        res = client.search(Query('quick').with_scores())
+        self.assertEqual(1.0, res.docs[0].score)
+        res = client.search(Query('quick').scorer('TFIDF').with_scores())
+        self.assertEqual(1.0, res.docs[0].score)
 
-        res = client.search(Query('quick').scorer('TFIDF.DOCNORM'))
-        self.assertEqual('doc1', res.docs[0].id)
+        res = client.search(Query('quick').scorer('TFIDF.DOCNORM').with_scores())
+        self.assertEqual(0.1111111111111111, res.docs[0].score)
+
+        res = client.search(Query('quick').scorer('BM25').with_scores())
+        self.assertEqual(0.17699114465425977, res.docs[0].score)
+
+        res = client.search(Query('quick').scorer('DISMAX').with_scores())
+        self.assertEqual(2.0, res.docs[0].score)
+
+        res = client.search(Query('quick').scorer('DOCSCORE').with_scores())
+        self.assertEqual(1.0, res.docs[0].score)
+
+        res = client.search(Query('quick').scorer('HAMMING').with_scores())
+        self.assertEqual(0.0, res.docs[0].score)
 
     def testGet(self):
         client = self.getCleanClient('idx')


### PR DESCRIPTION
Add support for using custom scoring functions in a Redisearch query.

Closes #35 

TFIDF is the default scoring function but this PR allows users to attach custom scoring functions to a Query object.

* TFIDF.DOCNORM
* BM25 
* DISMAX 
* DOCSCORE
* HAMMING

```python
res = client.search(Query('foo').scorer('TFIDF.DOCNORM'))
```

https://oss.redislabs.com/redisearch/Scoring/ 