### PR TITLE
transaction needs to be set to false, pipeline is OK tho

### DIFF
--- a/redisearch/auto_complete.py
+++ b/redisearch/auto_complete.py
@@ -84,7 +84,8 @@ class AutoCompleter(object):
 
         If kwargs['increment'] is true and the terms are already in the server's dictionary, we increment their scores
         """
-        pipe = self.redis.pipeline()
+        # If Transaction is not set to false it will attempt a MULTI/EXEC which will error
+        pipe = self.redis.pipeline(transaction=False)
         for sug in suggestions:
             args = [AutoCompleter.SUGADD_COMMAND, self.key, sug.string, sug.score]
             if kwargs.get('increment'):


### PR DESCRIPTION
If we do not set the transaction to false when adding items to the Auto completer we get the following error:

```
MULTI
*4
$9
FT.SUGADD
$2
ac
$7
Walmart
$3
1.0
*1
$4
EXEC
+OK
+QUEUED
*1
-ERR Blocking module command called from transaction
```